### PR TITLE
feat: show countdown since last fire

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,16 @@
 'use client';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getLastFire } from '../src/shared/api/fire';
 
 export default function HomePage() {
   const { data } = useQuery({ queryKey: ['lastFire'], queryFn: getLastFire });
-  const today = new Date();
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   if (!data) {
     return (
@@ -13,10 +19,12 @@ export default function HomePage() {
   }
 
   const lastDate = new Date(data.datetime);
-  const isToday = lastDate.toDateString() === today.toDateString();
-  const daysSince = Math.floor(
-    (today.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24),
-  );
+  const isToday = lastDate.toDateString() === now.toDateString();
+  const diffMs = now.getTime() - lastDate.getTime();
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diffMs / (1000 * 60 * 60)) % 24);
+  const minutes = Math.floor((diffMs / (1000 * 60)) % 60);
+  const seconds = Math.floor((diffMs / 1000) % 60);
 
   const labelStyle = {
     opacity: 0.9,
@@ -53,8 +61,11 @@ export default function HomePage() {
           <h1 style={{ ...labelStyle, fontSize: '4rem', color: 'green' }}>
             NO
           </h1>
-          <p style={{ ...labelStyle, marginTop: '1rem', fontSize: '1.5rem' }}>
-            {daysSince} days since last fire.
+          <p
+            style={{ ...labelStyle, marginTop: '1rem', fontSize: '1.5rem' }}
+            data-testid="countdown"
+          >
+            {`${days}d ${hours}h ${minutes}m ${seconds}s since last fire.`}
           </p>
         </>
       )}

--- a/tests/e2e/fire.spec.ts
+++ b/tests/e2e/fire.spec.ts
@@ -3,4 +3,12 @@ import { test, expect } from '@playwright/test';
 test('home page shows fire status', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByText(/NO|YES/)).toBeVisible();
+
+  const counter = page.getByTestId('countdown');
+  await expect(counter).toBeVisible();
+
+  const first = await counter.textContent();
+  await page.waitForTimeout(1100);
+  const second = await counter.textContent();
+  expect(first).not.toBe(second);
 });


### PR DESCRIPTION
## Summary
- display a live days/hours/minutes/seconds counter when no fire today
- test that the countdown updates over time

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm e2e`


------
https://chatgpt.com/codex/tasks/task_e_68ba92dd98588322ba45e5998005b4a1