### PR TITLE
feat: show latest fire photo as background

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import Providers from './providers';
 import { getLastFire } from '../src/shared/api/fire';
 
+export const dynamic = 'force-dynamic';
+
 export default async function RootLayout({
   children,
 }: {
@@ -14,6 +16,7 @@ export default async function RootLayout({
           backgroundImage: incident ? `url(${incident.photo_url})` : undefined,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
+          backgroundColor: '#000',
           margin: 0,
           minHeight: '100vh',
         }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,8 +27,12 @@ export default function HomePage() {
   const seconds = Math.floor((diffMs / 1000) % 60);
 
   const labelStyle = {
-    opacity: 0.9,
-    textShadow: '0 0 4px rgba(0, 0, 0, 0.5)',
+    display: 'inline-block',
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    color: '#fff',
+    padding: '0.25rem 0.5rem',
+    borderRadius: '0.25rem',
+    textShadow: '0 0 4px rgba(0, 0, 0, 0.8)',
   } as const;
 
   return (
@@ -51,6 +55,7 @@ export default function HomePage() {
               href={`https://www.google.com/maps/search/${encodeURIComponent(`${data.street}, Chisinau`)}`}
               target="_blank"
               rel="noopener noreferrer"
+              style={{ color: 'inherit', textDecoration: 'underline' }}
             >
               {data.street}
             </a>


### PR DESCRIPTION
## Summary
- fetch the most recent fire incident photo for background every request
- ensure labels have high-contrast styling over any photo

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68be8852bb908322aed5459a9abcaf63