### PR TITLE
feat: show monthly and yearly fire counts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,14 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getLastFire } from '../src/shared/api/fire';
+import { getLastFire, getFireStats } from '../src/shared/api/fire';
 
 export default function HomePage() {
   const { data } = useQuery({ queryKey: ['lastFire'], queryFn: getLastFire });
+  const { data: stats } = useQuery({
+    queryKey: ['fireStats'],
+    queryFn: getFireStats,
+  });
   const [now, setNow] = useState(new Date());
 
   useEffect(() => {
@@ -73,6 +77,19 @@ export default function HomePage() {
             {`${days}d ${hours}h ${minutes}m ${seconds}s since last fire.`}
           </p>
         </>
+      )}
+      {stats && (
+        <div
+          style={{
+            position: 'fixed',
+            bottom: '1rem',
+            right: '1rem',
+            ...labelStyle,
+          }}
+          data-testid="stats"
+        >
+          {`${stats.month} this month / ${stats.year} this year`}
+        </div>
       )}
     </main>
   );

--- a/tests/e2e/fire.spec.ts
+++ b/tests/e2e/fire.spec.ts
@@ -11,4 +11,8 @@ test('home page shows fire status', async ({ page }) => {
   await page.waitForTimeout(1100);
   const second = await counter.textContent();
   expect(first).not.toBe(second);
+
+  const stats = page.getByTestId('stats');
+  await expect(stats).toBeVisible();
+  await expect(stats).toHaveText('1 this month / 2 this year');
 });

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -2,15 +2,37 @@ import { http, HttpResponse } from 'msw';
 
 const SUPABASE_URL = 'https://supabase.test';
 
+const incidents = [
+  {
+    id: 1,
+    datetime: '2024-09-01T10:00:00Z',
+    photo_url: 'http://example.com/photo.jpg',
+    street: 'Stefan cel Mare',
+  },
+  {
+    id: 2,
+    datetime: '2024-06-15T10:00:00Z',
+    photo_url: 'http://example.com/photo2.jpg',
+    street: 'Dacia',
+  },
+  {
+    id: 3,
+    datetime: '2023-12-31T10:00:00Z',
+    photo_url: 'http://example.com/photo3.jpg',
+    street: 'Independence',
+  },
+];
+
 export const handlers = [
-  http.get(`${SUPABASE_URL}/rest/v1/fire_incidents`, () =>
-    HttpResponse.json([
-      {
-        id: 1,
-        datetime: '2024-09-01T10:00:00Z',
-        photo_url: 'http://example.com/photo.jpg',
-        street: 'Stefan cel Mare',
-      },
-    ]),
-  ),
+  http.get(`${SUPABASE_URL}/rest/v1/fire_incidents`, ({ request }) => {
+    const url = new URL(request.url);
+    const datetime = url.searchParams.get('datetime');
+    if (datetime?.startsWith('gte.')) {
+      const iso = datetime.slice(4);
+      return HttpResponse.json(
+        incidents.filter((i) => new Date(i.datetime) >= new Date(iso)),
+      );
+    }
+    return HttpResponse.json(incidents);
+  }),
 ];

--- a/tests/unit/fire.test.ts
+++ b/tests/unit/fire.test.ts
@@ -1,14 +1,23 @@
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
 
-import { beforeAll, afterEach, afterAll, describe, it, expect } from 'vitest';
+import {
+  beforeAll,
+  afterEach,
+  afterAll,
+  describe,
+  it,
+  expect,
+  vi,
+} from 'vitest';
 import { server } from '../msw/server';
 
 let getLastFire: (typeof import('../../src/shared/api/fire'))['getLastFire'];
+let getFireStats: (typeof import('../../src/shared/api/fire'))['getFireStats'];
 
 beforeAll(async () => {
   server.listen();
-  ({ getLastFire } = await import('../../src/shared/api/fire'));
+  ({ getLastFire, getFireStats } = await import('../../src/shared/api/fire'));
 });
 
 afterEach(() => server.resetHandlers());
@@ -18,5 +27,15 @@ describe('getLastFire', () => {
   it('fetches last fire incident', async () => {
     const incident = await getLastFire();
     expect(incident?.street).toBe('Stefan cel Mare');
+  });
+});
+
+describe('getFireStats', () => {
+  it('counts fires for month and year', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-09-10T12:00:00Z'));
+    const stats = await getFireStats();
+    expect(stats).toEqual({ month: 1, year: 2 });
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- display count of fire incidents this month and year in UI
- add API helper and tests for fire stats

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm e2e` *(fails: Executable doesn't exist at chromium_headless_shell; run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68be8c7829c4832288d8920c76020b06